### PR TITLE
Updates to documentation and minor version tweaks

### DIFF
--- a/.github/workflows/cli-native-images.yml
+++ b/.github/workflows/cli-native-images.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        graalvm-version: ['22.1.0']
+        graalvm-version: ['22.1.0','22.3.0']
         jdk-version: ['17']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:

--- a/.github/workflows/cli-native-images.yml
+++ b/.github/workflows/cli-native-images.yml
@@ -59,13 +59,13 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build native image on Linux
-        run: native-image --enable-url-protocols=https --static -jar astra-cli-*.jar astra-cli-linux
+        run: native-image --enable-url-protocols=https --static -H:+ReportExceptionStackTraces -jar astra-cli-*.jar astra-cli-linux
         if: runner.os == 'Linux'
       - name: Build native image on Mac OS X
-        run: native-image --enable-url-protocols=https -jar astra-cli-*.jar astra-cli-macos
+        run: native-image --enable-url-protocols=https -H:+ReportExceptionStackTraces -jar astra-cli-*.jar astra-cli-macos
         if: runner.os == 'macOS'
       - name: Build native image on Windows
-        run: native-image --enable-url-protocols=https -jar astra-cli-*.jar astra-cli-windows.exe
+        run: native-image --enable-url-protocols=https -H:+ReportExceptionStackTraces -jar astra-cli-*.jar astra-cli-windows.exe
         if: runner.os == 'Windows'
       - name: Temporarily save package
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cli-nightly-build.yml
+++ b/.github/workflows/cli-nightly-build.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "17"
-          distribution: "adopt"
+          distribution: "temurin"
       - name: Test with Maven
         run: mvn compile
         

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ chances of your issue being dealt with quickly:
 ### <a name="submit-pr"></a> Submitting a Pull Request (PR)
 Before you submit your Pull Request (PR) consider the following guidelines:
 
-* Search the repository (https://github.com/bechbd/[repository-name]/pulls) for an open or closed PR that relates to your submission. You don't want to duplicate effort.
+* Search the repository (https://github.com/datastax/astra-cli/pulls) for an open or closed PR that relates to your submission. You don't want to duplicate effort.
 
 * Create a fork of the repo
 	* Navigate to the repo you want to fork
@@ -55,4 +55,6 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     git push -f
     ```
 
-That's it! Thank you for your contribution!
+That's it! Thank you for your contribution! 🫶
+
+---

--- a/README.MD
+++ b/README.MD
@@ -13,10 +13,10 @@
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=clun_astra-cli&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=clun_astra-cli)
 ![downloads](https://img.shields.io/github/downloads/datastax/astra-cli/total)
 
-Astra CLI provides a command line interface in a terminal to operate Datastax Astra. The goal is to offer access to any feature without accessing the user interface. The component is still under development (version `0.1.alpha5`), it will keep moving before the release GA.
+Astra CLI provides a command line interface in a terminal to operate DataStax Astra. The goal is to offer access to any feature without accessing the user interface.
 
 > ```
-> The component is still under development (version `0.1.alpha5`)
+> The component was made generally available in 2022. See [this blog](https://www.datastax.com/blog/introducing-cassandra-astra-cli) for more details or refer to the [Releases](https://github.com/datastax/astra-cli/releases) section.
 > ```
 
 ## Getting started
@@ -45,3 +45,4 @@ astra setup
 astra db list
 ```
 
+---

--- a/pom.xml
+++ b/pom.xml
@@ -392,11 +392,17 @@
 			<email>cedrick.lunven@gmail.com</email>
 			<url>https://github.com/clun</url>
 		</developer>
+		<developer>
+			<id>msmygit</id>
+			<name>Madhavan S.</name>
+			<email>madhavan_5k@yahoo.com</email>
+			<url>https://github.com/msmygit</url>
+		</developer>
 	</developers>
 
 	<organization>
 		<name>DataStax</name>
-		<url>http://datastax.com</url>
+		<url>https://www.datastax.com</url>
 	</organization>
 	
 	<licenses>


### PR DESCRIPTION
Updates to documentation, migrate nightly build from Adopt to leverage Temurin JDK and add GraalVM `22.3.0` to the testing mix.