### PR TITLE
Re-introduce securely masking Astra token on the console feature

### DIFF
--- a/src/main/java/com/dtsx/astra/cli/config/SetupCmd.java
+++ b/src/main/java/com/dtsx/astra/cli/config/SetupCmd.java
@@ -65,9 +65,34 @@ public class SetupCmd extends AbstractCmd {
         AstraEnvironment targetEnv = AstraCliUtils.parseEnvironment(env);
         // As not token is provided we ask for it in the console
         if (token == null || token.isBlank()) {
+            verbose = true;
+            AstraCliConsole.banner();
+            boolean validToken = false;
+            Console cons;
+            char[] tokenFromConsole;
+            while (!validToken) {
+                try {
+                    if ((cons = System.console()) != null &&
+                            (tokenFromConsole = cons.readPassword("[%s]", "$ Enter an Astra token:")) != null) {
+                        token = String.valueOf(tokenFromConsole);
 
+                        // Clear the password from memory immediately when done
+                        Arrays.fill(tokenFromConsole, ' ');
+                    } else {
+                        try (Scanner scanner = new Scanner(System.in)) {
+                            AstraCliConsole.println("$ Enter an Astra token:", CYAN_400);
+                            token = scanner.nextLine();
+                        }
+                    }
+                    createDefaultSection();
+                    validToken = true;
+                } catch(InvalidTokenException ite) {
+                    LoggerShell.error("Your token in invalid please retry " + ite.getMessage());
+                }
+            }
+        } else {
+            createDefaultSection();
         }
-        createDefaultSection();
     }
     
     /**


### PR DESCRIPTION
changes from https://github.com/datastax/astra-cli/pull/116/files is reverted in the recent commit here, [8ab22c211382e5ba2ddc1c30661b0bc8c6e8f927](https://github.com/datastax/astra-cli/commit/8ab22c211382e5ba2ddc1c30661b0bc8c6e8f927#diff-4bf4d01004d6d14021c1ae247f6c72016e34dc9db79626b13f7591db17a8b62fL65) which was originally done to address this security ask