### PR TITLE
fix Arbitrary file access during archive extraction ("Zip Slip") FileUtils()

### DIFF
--- a/src/main/java/com/dtsx/astra/cli/utils/FileUtils.java
+++ b/src/main/java/com/dtsx/astra/cli/utils/FileUtils.java
@@ -108,8 +108,12 @@ public class FileUtils {
                   TarArchiveEntry tarEntry;
                   while ((tarEntry = tis.getNextTarEntry()) != null) {
                       // Escaping to remove invalid entry
-                      File outputFile = Paths.get(AstraCliUtils.ASTRA_HOME + File.separator +
-                              Paths.get(tarEntry.getName()).normalize()).toFile();
+                      Path outputPath = Paths.get(AstraCliUtils.ASTRA_HOME).resolve(Paths.get(tarEntry.getName()).normalize());
+                      if (!outputPath.normalize().startsWith(Paths.get(AstraCliUtils.ASTRA_HOME))) {
+                          LoggerShell.warn("Skipping invalid tar entry: " + tarEntry.getName());
+                          continue;
+                      }
+                      File outputFile = outputPath.toFile();
                       if (tarEntry.isDirectory()) {
                         if (!outputFile.exists() && outputFile.mkdirs())
                           LoggerShell.debug(CREATE_FOLDER_MSG


### PR DESCRIPTION
https://github.com/datastax/astra-cli/blob/bab2edb1cbac0ed48642b116f7b29f7839bde7f6/src/main/java/com/dtsx/astra/cli/utils/FileUtils.java#L112-L112

fix the issue need to ensure that the extracted file paths are validated to prevent directory traversal attacks. Specifically:
1. Normalize the path of the extracted file using `Path.normalize()` or `File.getCanonicalFile()`.
2. Verify that the normalized path starts with the intended base directory (`AstraCliUtils.ASTRA_HOME`) using `Path.startsWith()` or equivalent.
3. If the path is invalid (i.e., it does not start with the base directory), throw an exception or skip the entry.

The changes will be made in the `extractTarArchiveInAstraCliHome` method. Specifically:
- After constructing the `outputFile` path, validate that it starts with the intended base directory.
- If the validation fails, log a warning and skip the entry.

Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. Zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (`..`). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

if a zip file contains a file entry `..\astra-cli-file`, and the zip file is extracted to the directory c:\output, then naively combining the paths would result in an output file path of `c:\output\..\astra-cli-file`, which would cause the file to be written to `c:\astra-file`.



## Recommendation
Ensure that output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. The recommended way of writing an output file from a zip archive entry is to verify that the normalized full path of the output file starts with a prefix that matches the destination directory. Path normalization can be done with either `java.io.File.getCanonicalFile()` or `java.nio.file.Path.normalize()`. Prefix checking can be done with `String.startsWith(..)`, but it is better to use `java.nio.file.Path.startsWith(..)`, as the latter works on complete path segments.


## POC
a file path taken from a zip archive item entry is combined with a destination directory. The result is used as the destination file path without verifying that the result is within the destination directory. If provided with a zip file containing an archive path like `..\datastax-file`, then this file would be written outside the destination directory.
```java
void writeZipEntry(ZipEntry entry, File destinationDir) {
    File file = new File(destinationDir, entry.getName());
    FileOutputStream fos = new FileOutputStream(file); // BAD
    // ... write entry to fos ...
}
```
To fix this vulnerability, we need to verify that the normalized `file` still has `destinationDir` as its prefix, and throw an exception if this is not the case.
```java
void writeZipEntry(ZipEntry entry, File destinationDir) {
    File file = new File(destinationDir, entry.getName());
    if (!file.toPath().normalize().startsWith(destinationDir.toPath()))
        throw new Exception("Bad zip entry");
    FileOutputStream fos = new FileOutputStream(file); // OK
    // ... write entry to fos ...
}
```
## References
[Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability)
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)
