### PR TITLE
feat: allow API endpoint URLs to be used as database references

### DIFF
--- a/src/main/java/com/dtsx/astra/cli/core/models/DbRef.java
+++ b/src/main/java/com/dtsx/astra/cli/core/models/DbRef.java
@@ -1,5 +1,6 @@
 package com.dtsx.astra.cli.core.models;
 
+import com.datastax.astra.internal.api.AstraApiEndpoint;
 import com.dtsx.astra.cli.core.CliContext;
 import com.dtsx.astra.cli.core.datatypes.Either;
 import com.dtsx.astra.cli.core.output.Highlightable;
@@ -7,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.*;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -16,15 +16,15 @@ import static com.dtsx.astra.cli.utils.CollectionUtils.sequencedMapOf;
 @EqualsAndHashCode
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class DbRef implements Highlightable {
-    private static final int UUID_LENGTH = 36;
-
     private final Either<UUID, String> ref;
 
     public static Either<String, DbRef> parse(@NonNull String ref) {
         return ModelUtils.trimAndValidateBasics("Database name/id", ref).flatMap((trimmed) -> {
-            val maybeIdFromEndpoint = tryParseEndpointUrl(trimmed);
-            if (maybeIdFromEndpoint.isPresent()) {
-                return Either.pure(new DbRef(Either.left(maybeIdFromEndpoint.get())));
+            try {
+                val endpoint = AstraApiEndpoint.parse(trimmed);
+                return Either.pure(new DbRef(Either.left(endpoint.getDatabaseId())));
+            } catch (Exception e) {
+                // not a valid Astra endpoint URL, fall through
             }
 
             try {
@@ -33,26 +33,6 @@ public class DbRef implements Highlightable {
                 return Either.pure(new DbRef(Either.pure(trimmed)));
             }
         });
-    }
-
-    private static Optional<UUID> tryParseEndpointUrl(String input) {
-        if (!input.startsWith("https://") && !input.startsWith("http://")) {
-            return Optional.empty();
-        }
-
-        val hostStart = input.indexOf("://") + 3;
-        val afterScheme = input.substring(hostStart);
-        val host = afterScheme.contains("/") ? afterScheme.substring(0, afterScheme.indexOf('/')) : afterScheme;
-
-        if (host.length() <= UUID_LENGTH || host.charAt(UUID_LENGTH) != '-') {
-            return Optional.empty();
-        }
-
-        try {
-            return Optional.of(UUID.fromString(host.substring(0, UUID_LENGTH)));
-        } catch (IllegalArgumentException e) {
-            return Optional.empty();
-        }
     }
 
     public static DbRef fromNameUnsafe(@NonNull String name) {

--- a/src/main/java/com/dtsx/astra/cli/core/models/DbRef.java
+++ b/src/main/java/com/dtsx/astra/cli/core/models/DbRef.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.*;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -15,16 +16,43 @@ import static com.dtsx.astra.cli.utils.CollectionUtils.sequencedMapOf;
 @EqualsAndHashCode
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class DbRef implements Highlightable {
+    private static final int UUID_LENGTH = 36;
+
     private final Either<UUID, String> ref;
 
     public static Either<String, DbRef> parse(@NonNull String ref) {
         return ModelUtils.trimAndValidateBasics("Database name/id", ref).flatMap((trimmed) -> {
+            val maybeIdFromEndpoint = tryParseEndpointUrl(trimmed);
+            if (maybeIdFromEndpoint.isPresent()) {
+                return Either.pure(new DbRef(Either.left(maybeIdFromEndpoint.get())));
+            }
+
             try {
                 return Either.pure(new DbRef(Either.left(UUID.fromString(trimmed))));
             } catch (IllegalArgumentException e) {
                 return Either.pure(new DbRef(Either.pure(trimmed)));
             }
         });
+    }
+
+    private static Optional<UUID> tryParseEndpointUrl(String input) {
+        if (!input.startsWith("https://") && !input.startsWith("http://")) {
+            return Optional.empty();
+        }
+
+        val hostStart = input.indexOf("://") + 3;
+        val afterScheme = input.substring(hostStart);
+        val host = afterScheme.contains("/") ? afterScheme.substring(0, afterScheme.indexOf('/')) : afterScheme;
+
+        if (host.length() <= UUID_LENGTH || host.charAt(UUID_LENGTH) != '-') {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(UUID.fromString(host.substring(0, UUID_LENGTH)));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
     }
 
     public static DbRef fromNameUnsafe(@NonNull String name) {

--- a/src/test/java/com/dtsx/astra/cli/unit/core/models/DbRefTest.java
+++ b/src/test/java/com/dtsx/astra/cli/unit/core/models/DbRefTest.java
@@ -1,0 +1,88 @@
+package com.dtsx.astra.cli.unit.core.models;
+
+import com.dtsx.astra.cli.core.models.DbRef;
+import com.dtsx.astra.cli.unit.BaseParseableTest;
+import lombok.val;
+import net.jqwik.api.Example;
+import net.jqwik.api.Group;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DbRefTest extends BaseParseableTest.WithTrimAndBasicValidation {
+    private static final UUID SAMPLE_ID = UUID.fromString("822b0fff-6a73-4322-a8ec-09832b075287");
+
+    public DbRefTest() {
+        super("Database name/id", DbRef::parse);
+    }
+
+    @Group
+    public class from_name {
+        @Example
+        public void parses_plain_name_as_name_ref() {
+            val result = DbRef.parse("my-database");
+            assertThat(result.getRight().isName()).isTrue();
+            assertThat(result.getRight().toString()).isEqualTo("my-database");
+        }
+    }
+
+    @Group
+    public class from_uuid {
+        @Example
+        public void parses_uuid_as_id_ref() {
+            val result = DbRef.parse(SAMPLE_ID.toString());
+            assertThat(result.getRight().isId()).isTrue();
+            assertThat(result.getRight().toString()).isEqualTo(SAMPLE_ID.toString());
+        }
+    }
+
+    @Group
+    public class from_endpoint_url {
+        @Example
+        public void parses_prod_api_endpoint() {
+            val url = "https://" + SAMPLE_ID + "-us-east1.apps.astra.datastax.com";
+            val result = DbRef.parse(url);
+            assertThat(result.getRight().isId()).isTrue();
+            assertThat(result.getRight().toString()).isEqualTo(SAMPLE_ID.toString());
+        }
+
+        @Example
+        public void parses_dev_api_endpoint() {
+            val url = "https://" + SAMPLE_ID + "-ap-south-1.apps.astra-dev.datastax.com";
+            val result = DbRef.parse(url);
+            assertThat(result.getRight().isId()).isTrue();
+            assertThat(result.getRight().toString()).isEqualTo(SAMPLE_ID.toString());
+        }
+
+        @Example
+        public void parses_endpoint_with_path() {
+            val url = "https://" + SAMPLE_ID + "-us-east1.apps.astra.datastax.com/api/json/v1";
+            val result = DbRef.parse(url);
+            assertThat(result.getRight().isId()).isTrue();
+            assertThat(result.getRight().toString()).isEqualTo(SAMPLE_ID.toString());
+        }
+
+        @Example
+        public void parses_swagger_endpoint() {
+            val url = "https://" + SAMPLE_ID + "-ap-south-1.apps.astra-dev.datastax.com/api/json/swagger-ui";
+            val result = DbRef.parse(url);
+            assertThat(result.getRight().isId()).isTrue();
+            assertThat(result.getRight().toString()).isEqualTo(SAMPLE_ID.toString());
+        }
+
+        @Example
+        public void falls_back_to_name_for_non_astra_url() {
+            val url = "https://some-other-host.example.com/path";
+            val result = DbRef.parse(url);
+            assertThat(result.getRight().isName()).isTrue();
+        }
+
+        @Example
+        public void falls_back_to_name_when_url_has_no_uuid_prefix() {
+            val url = "https://not-a-uuid-at-all.apps.astra.datastax.com";
+            val result = DbRef.parse(url);
+            assertThat(result.getRight().isName()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
Parses the database UUID from Astra endpoint URLs of the form:
  https://<uuid>-<region>.apps.astra*.datastax.com[/...]

No change to existing internals - DbRef.parse() now checks for an HTTP(S) URL first, extracts the 36-char UUID prefix from the hostname if present, and falls through to the existing UUID/name logic otherwise.

Closes #289