### PR TITLE
fix: Properly slice the line between backslashes

### DIFF
--- a/src/main/java/com/dtsx/astra/cli/commands/db/cqlsh/CqlshStartImpl.java
+++ b/src/main/java/com/dtsx/astra/cli/commands/db/cqlsh/CqlshStartImpl.java
@@ -105,7 +105,7 @@ public abstract class CqlshStartImpl extends AbstractCqlshExecCmd {
 
             while ((line = reader.readLine()) != null) {
                 if (line.trim().endsWith("\\")) {
-                    sb.append(line, 0, line.lastIndexOf('\\') - 1); // TODO this should not be -1
+                    sb.append(line, 0, line.lastIndexOf('\\'));
                     sb.append(NL);
                 } else {
                     sb.append(line);

--- a/src/main/java/com/dtsx/astra/cli/commands/db/cqlsh/CqlshStartImpl.java
+++ b/src/main/java/com/dtsx/astra/cli/commands/db/cqlsh/CqlshStartImpl.java
@@ -105,7 +105,7 @@ public abstract class CqlshStartImpl extends AbstractCqlshExecCmd {
 
             while ((line = reader.readLine()) != null) {
                 if (line.trim().endsWith("\\")) {
-                    sb.append(line, 0, line.lastIndexOf('\\'));
+                    sb.append(line.substring(0, line.lastIndexOf('\\')).stripTrailing());
                     sb.append(NL);
                 } else {
                     sb.append(line);


### PR DESCRIPTION
Fixes #292 

This pull request fixes a bug in the `readStdin` method related to how lines ending with a backslash are handled. Specifically, it corrects the substring range so that the backslash character is properly excluded from the appended result.

- Bug fix in input reading:
  * Corrected the substring range in the `readStdin` method of `CqlshStartImpl.java` to exclude the trailing backslash from lines ending with `This pull request fixes a bug in the `readStdin` method related to how lines ending with a backslash are handled. Specifically, it corrects the substring range so that the backslash character is properly excluded from the appended result.